### PR TITLE
Fix a variety of build issues (mostly cherry-picked from later releases)

### DIFF
--- a/Changes
+++ b/Changes
@@ -5,6 +5,10 @@ Working version
 
 - GPR#1752: do not alias function arguments to sigprocmask (Anil Madhavapeddy)
 
+### Tools:
+
+- GPR#1753: avoid potential off-by-one overflow in debugger socket path
+  length (Anil Madhavapeddy)
 
 OCaml 4.04.0:
 -------------

--- a/Changes
+++ b/Changes
@@ -1,3 +1,11 @@
+Working version
+---------------
+
+### Runtime system:
+
+- GPR#1752: do not alias function arguments to sigprocmask (Anil Madhavapeddy)
+
+
 OCaml 4.04.0:
 -------------
 

--- a/asmrun/startup.c
+++ b/asmrun/startup.c
@@ -46,6 +46,7 @@
 extern int caml_parser_trace;
 CAMLexport header_t caml_atom_table[256];
 char * caml_code_area_start, * caml_code_area_end;
+struct ext_table caml_code_fragments_table;
 
 /* Initialize the atom table and the static data and code area limits. */
 

--- a/asmrun/startup.c
+++ b/asmrun/startup.c
@@ -44,7 +44,7 @@
 #endif
 
 extern int caml_parser_trace;
-CAMLexport header_t caml_atom_table[256];
+extern header_t caml_atom_table[256];
 char * caml_code_area_start, * caml_code_area_end;
 struct ext_table caml_code_fragments_table;
 

--- a/byterun/backtrace.c
+++ b/byterun/backtrace.c
@@ -28,7 +28,7 @@
 #include "caml/fail.h"
 
 /* The table of debug information fragments */
-struct ext_table caml_debug_info;
+extern struct ext_table caml_debug_info;
 
 CAMLexport int32_t caml_backtrace_active = 0;
 CAMLexport int32_t caml_backtrace_pos = 0;

--- a/byterun/caml/intext.h
+++ b/byterun/caml/intext.h
@@ -196,7 +196,7 @@ struct code_fragment {
 
 CAMLextern struct code_fragment * caml_extern_find_code(char *addr);
 
-struct ext_table caml_code_fragments_table;
+extern struct ext_table caml_code_fragments_table;
 
 #endif /* CAML_INTERNALS */
 

--- a/byterun/caml/major_gc.h
+++ b/byterun/caml/major_gc.h
@@ -64,9 +64,9 @@ extern uintnat total_heap_size;
 extern char *caml_gc_sweep_hp;
 
 extern int caml_major_window;
-double caml_major_ring[Max_major_window];
-int caml_major_ring_index;
-double caml_major_work_credit;
+extern double caml_major_ring[Max_major_window];
+extern int caml_major_ring_index;
+extern double caml_major_work_credit;
 extern double caml_gc_clock;
 
 /* [caml_major_gc_hook] is called just between the end of the mark

--- a/byterun/debugger.c
+++ b/byterun/debugger.c
@@ -163,6 +163,7 @@ static void winsock_cleanup(void)
 void caml_debugger_init(void)
 {
   char * address;
+  size_t a_len;
   char * port, * p;
   struct hostent * host;
   int n;
@@ -190,11 +191,16 @@ void caml_debugger_init(void)
     /* Unix domain */
     sock_domain = PF_UNIX;
     sock_addr.s_unix.sun_family = AF_UNIX;
+    a_len = strlen(address);
+    if (a_len >= sizeof(sock_addr.s_unix.sun_path)) {
+      caml_fatal_error("Debug socket path length exceeds maximum permitted length");
+    }
     strncpy(sock_addr.s_unix.sun_path, address,
-            sizeof(sock_addr.s_unix.sun_path));
+            sizeof(sock_addr.s_unix.sun_path) - 1);
+    sock_addr.s_unix.sun_path[sizeof(sock_addr.s_unix.sun_path) - 1] = '\0';
     sock_addr_len =
       ((char *)&(sock_addr.s_unix.sun_path) - (char *)&(sock_addr.s_unix))
-        + strlen(address);
+        + a_len;
 #else
     caml_fatal_error("Unix sockets not supported");
 #endif

--- a/byterun/fix_code.c
+++ b/byterun/fix_code.c
@@ -36,6 +36,7 @@
 code_t caml_start_code;
 asize_t caml_code_size;
 unsigned char * caml_saved_code;
+struct ext_table caml_code_fragments_table;
 
 /* Read the main bytecode block from a file */
 

--- a/byterun/signals.c
+++ b/byterun/signals.c
@@ -144,12 +144,12 @@ void caml_execute_signal(int signal_number, int in_signal_handler)
   void* saved_spacetime_trie_node_ptr;
 #endif
 #ifdef POSIX_SIGNALS
-  sigset_t sigs;
+  sigset_t nsigs, sigs;
   /* Block the signal before executing the handler, and record in sigs
      the original signal mask */
-  sigemptyset(&sigs);
-  sigaddset(&sigs, signal_number);
-  sigprocmask(SIG_BLOCK, &sigs, &sigs);
+  sigemptyset(&nsigs);
+  sigaddset(&nsigs, signal_number);
+  sigprocmask(SIG_BLOCK, &nsigs, &sigs);
 #endif
 #if defined(NATIVE_CODE) && defined(WITH_SPACETIME)
   /* We record the signal handler's execution separately, in the same


### PR DESCRIPTION
- Avoid duplicate definitions of global variables (66b65ece)  
  Adapted from [d9a339bd](https://github.com/ocaml/ocaml/commit/d9a339bd5aa041c0f8f83a8e0b28d0f124440a68)

- Declare variables `extern` in `<caml/major_gc.h>` and `<caml/intext.h>` (fba4622d)
  (cherry-picked)
    
- debugger: avoid off-by-one overflow in debugger socket path (0e1237a6)  
  (cherry-picked)

- byterun: do not alias function arguments to sigprocmask (466253d2)  
  (cherry-picked)