### PR TITLE
Fix bugs in splicearray indexing

### DIFF
--- a/bytecomp/translcore.ml
+++ b/bytecomp/translcore.ml
@@ -713,9 +713,7 @@ let path_clos = ref (None : (Ident.t * int Env.PathMap.t) option)
 
 let set_transl_splices opt =
   splice_index := 0;
-  match opt with
-  | None -> splice_array := None
-  | Some a -> splice_array := Some a
+  splice_array := opt
 
 let rec transl_exp e =
   List.iter (Translattribute.check_attribute e) e.exp_attributes;
@@ -1162,7 +1160,9 @@ and transl_exp0 e =
       if Env.cur_stage e.exp_env = 0 then
         match !splice_array with
         | Some arr_ref ->
-            Array.get !arr_ref !splice_index
+           let idx = !splice_index in
+           incr splice_index;
+           Array.get !arr_ref idx
         | None ->
             assert false
       else (* else if we are inside a quote *)

--- a/bytecomp/translmod.ml
+++ b/bytecomp/translmod.ml
@@ -138,17 +138,17 @@ let transl_item_splices item item_lam =
   (* Find splices in current structure item *)
   TranslSplices.iter_structure_item item;
   (* Add the code for running splices *)
-  let wrap_seq str_lam (idx, splice_lam) =
-    Lsequence (
+  let wrap_seq str_lam splice_lam =
+    let idx = !nb_splices in
+    incr nb_splices;
+    (Lsequence (
       Lprim (Psetfield (idx, Pointer, Assignment),
         [Lvar splicearray_id;
           splice_lam], Location.none),
-      str_lam)
+      str_lam))
   in
-  let indexed_splices = List.mapi (fun i spl -> (i, spl)) !item_splices in
-  let lam = List.fold_left wrap_seq item_lam indexed_splices in
+  let lam = List.fold_left wrap_seq item_lam (List.rev !item_splices) in
   item_splices := [];
-  nb_splices := !nb_splices + List.length indexed_splices;
   lam
 
 let rec repeat n x =

--- a/testsuite/tests/macros/multiple_splices.ml
+++ b/testsuite/tests/macros/multiple_splices.ml
@@ -1,0 +1,5 @@
+let a = $(<<1>>)
+let b = $(<<"2">>)
+let c = $(<<'3'>>)
+let () = Printf.printf "%d %S %C\n" a b c
+;;

--- a/testsuite/tests/macros/multiple_splices.ml.reference
+++ b/testsuite/tests/macros/multiple_splices.ml.reference
@@ -1,0 +1,6 @@
+
+#         1 "2" '3'
+val a : int = 1
+val b : string = "2"
+val c : char = '3'
+# 


### PR DESCRIPTION
The following test program

```ocaml
let a = $(<<1>>)
let b = $(<<"2">>)
let c = $(<<'3'>>)
let () = Printf.printf "%d %S %C\n" a b c
```

previously crashed with a segmentation fault, but now prints `1 "2" '3'`, as expected.